### PR TITLE
bump versions

### DIFF
--- a/rootfs/build-latest
+++ b/rootfs/build-latest
@@ -32,10 +32,10 @@ declare -A versions
 versions[make]=4.1
 versions[linux]=3.18.5
 versions[musl]=1.0.4
-versions[skalibs]=2.3.1.0
+versions[skalibs]=2.3.1.1
 versions[execline]=2.1.1.0
 versions[s6]=2.1.2.0
-versions[s6-portable-utils]=2.0.3.0
+versions[s6-portable-utils]=2.0.4.0
 versions[s6-linux-utils]=2.0.1.0
 versions[s6-dns]=2.0.0.2
 versions[s6-networking]=2.1.0.0


### PR DESCRIPTION
skalibs 2.3.1.0 -> 2.3.1.1
s6-portable-utils 2.0.3.0 -> 2.0.4.0
