### PR TITLE
bump skaware versions

### DIFF
--- a/skarnet-builder/build-latest
+++ b/skarnet-builder/build-latest
@@ -39,10 +39,10 @@ declare -A versions
 versions[make]=4.1
 versions[linux]=3.18.5
 versions[musl]=1.0.5
-versions[skalibs]=2.3.6.0
-versions[execline]=2.1.3.0
-versions[s6]=2.2.0.0
-versions[s6-portable-utils]=2.0.5.0
+versions[skalibs]=2.3.7.0
+versions[execline]=2.1.4.0
+versions[s6]=2.2.1.0
+versions[s6-portable-utils]=2.0.5.2
 versions[s6-linux-utils]=2.0.2.1
 versions[s6-dns]=2.0.0.4
 versions[s6-networking]=2.1.0.1


### PR DESCRIPTION
`[announce] skarnet.org Fall 2015 update`:

```
 Hello,
 A series of small updates.

 * skalibs-2.3.7.0
 -----------------

 A few more utility functions such as touch(), filecopy_suffix(),
or atomic_rm_rf(). (Yes, that last one removes filesystem
hierarchies atomically. It's magic!)

 http://skarnet.org/software/skalibs/
 git://git.skarnet.org/skalibs

 * execline-2.1.4.0
 ------------------

 New commands: withstdinas, getcwd.
 backtick is now a wrapper around withstdinas.

 http://skarnet.org/software/execline/
 git://git.skarnet.org/execline

 * s6-2.2.1.0
 ------------

 A few minor bugfixes.
 s6-svstat now exits 1 when run on an unsupervised servicedir.
 New -wr and -wR options to s6-svc, s6-svlisten1 and s6-svlisten.
  http://skarnet.org/software/s6/
 git://git.skarnet.org/s6

 * s6-portable-utils-2.0.5.2
 ---------------------------

 A sensible interpretation of "s6-maximumtime 0 prog".

 http://skarnet.org/software/s6-portable-utils/
 git://git.skarnet.org/s6-portable-utils

 * s6-linux-init-0.0.1.3
 -----------------------

 A stage 1 that runs the supervision tree in another process
group than the kernel (there was no real impact, but some "ps"
implementations displayed the s6 processes as kernel threads...)

 http://skarnet.org/software/s6-linux-init/
 git://git.skarnet.org/s6-linux-init

 Enjoy,
 Bug-reports welcome.
```
