### PR TITLE
Update git clone for corporate firewalls

### DIFF
--- a/skarnet-builder/build-latest
+++ b/skarnet-builder/build-latest
@@ -95,7 +95,7 @@ build_install_skarnet_package() {
 
     cd "$BUILDDIR"
 
-    git clone git://git.skarnet.org/${package}
+    git clone https://github.com/skarnet/${package}.git
     cd ${package}
     if [[ ${version} =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
       version=$(git rev-list -n 1 v${version})


### PR DESCRIPTION
Update URL for git clone operations to use github HTTPS URLs for people behind a corporate firewall that prevents SSH access.
