### PR TITLE
upgrade packages: s6, s6-portable-utils, s6-rc and execline

### DIFF
--- a/skarnet-builder/build-latest
+++ b/skarnet-builder/build-latest
@@ -80,13 +80,13 @@ targets[powerpc64le-linux-musl]=ppc64le
 declare -A versions
 versions[make]=4.1
 versions[skalibs]=2.9.2.1
-versions[execline]=2.6.0.1
-versions[s6]=2.9.1.0
-versions[s6-portable-utils]=2.2.2.2
+versions[execline]=2.6.1.0
+versions[s6]=2.9.2.0
+versions[s6-portable-utils]=2.2.2.4
 versions[s6-linux-utils]=2.5.1.2
 versions[s6-dns]=2.3.2.0
 versions[s6-networking]=2.3.1.2
-versions[s6-rc]=0.5.1.2
+versions[s6-rc]=0.5.1.4
 
 declare -A manifests
 manifests[skarnet_all_packages]="manifest.txt"


### PR DESCRIPTION
Upgrades:

- `execline` to `2.6.1.0` 
   - ref: http://skarnet.org/software/execline/upgrade.html

- `s6` to `2.9.2.0`
   - ref: http://skarnet.org/software/s6/upgrade.html

- `s6-portable-utils` to `2.2.2.4` 
   - ref: http://skarnet.org/software/s6-portable-utils/upgrade.html

- `s6-rc` to `0.5.1.4` 
   - ref: http://skarnet.org/software/s6-rc/upgrade.html