### PR TITLE
Add riscv64 support

### DIFF
--- a/skarnet-builder/build-latest
+++ b/skarnet-builder/build-latest
@@ -64,6 +64,7 @@ targets_order=(
 'arm-linux-musleabi'
 'arm-linux-musleabihf'
 'powerpc64le-linux-musl'
+'riscv64-linux-musl'
 )
 
 # target platforms + simplified
@@ -74,6 +75,7 @@ targets[aarch64-linux-musl]=aarch64
 targets[x86_64-linux-musl]=amd64
 targets[i486-linux-musl]=x86
 targets[powerpc64le-linux-musl]=ppc64le
+targets[riscv64-linux-musl]=riscv64
 
 # software versions
 declare -A versions


### PR DESCRIPTION
I suggest to build skaware, along with the other libraries included in s6-overlay for riscv64.

The project already supports many other architectures, and as far as I can tell, adding riscv64 would be quite easy - in this case, the musl-cross-make support is already present.

This is based on the previous ppc64le work.
https://github.com/just-containers/skaware/commit/733fee41b356b5a1edf41cdf5c52f101dc8ba4e0